### PR TITLE
Move default config option to bottom of select dropdown

### DIFF
--- a/src/views/home/SubTable.vue
+++ b/src/views/home/SubTable.vue
@@ -33,10 +33,10 @@
                 <div class="col-8 col-md-10">
                   <label class="form-label" for="remote">远程配置</label>
                   <select class="form-select" id="remote" @change="selectRemoteConfig">
-                    <option value="">默认配置</option>
                     <option v-for="option in remoteConfigOptions" :key="option" :value="option.value">
                       {{ option.text }}
                     </option>
+                    <option value="">默认配置</option>
                     <option value="manual">自定义远程配置地址</option>
                   </select>
                 </div>


### PR DESCRIPTION
## Changes Made
- Moved the "默认配置" (Default Config) option from the top to the bottom of the select dropdown
- Custom remote configuration options now appear before the default option
- Improved user experience by prioritizing custom configurations

## Reason for Change
This change enhances the user interface by showing the most commonly used options (custom configurations) first, while keeping the default option available but less prominent.
